### PR TITLE
Add policy creation form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'sinatra-activerecord'
 gem 'pg'
 gem 'rake'
 gem 'jwt'
+gem 'sinatra-flash'
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       rack-protection (= 4.0.0)
       sinatra (= 4.0.0)
       tilt (~> 2.0)
+    sinatra-flash (0.3.0)
+      sinatra (>= 1.0.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -150,6 +152,7 @@ DEPENDENCIES
   sinatra
   sinatra-activerecord
   sinatra-contrib
+  sinatra-flash
   webmock
 
 BUNDLED WITH

--- a/clients/graphql_client.rb
+++ b/clients/graphql_client.rb
@@ -28,7 +28,7 @@ class GraphqlClient
     end
 
     def token
-      @token ||= JWT.encode({ exp: Time.now.to_i + ONE_MINUTE }, ENV['JWT_SECRET'], 'HS256')
+      JWT.encode({ exp: Time.now.to_i + ONE_MINUTE }, ENV['JWT_SECRET'], 'HS256')
     end
   end
 end

--- a/controllers/base_controller.rb
+++ b/controllers/base_controller.rb
@@ -1,9 +1,12 @@
 require 'sinatra/content_for'
+require 'sinatra/flash'
 
 class BaseController < Sinatra::Base
   helpers Sinatra::ContentFor
 
   set :views, File.expand_path('../../views', __FILE__)
+
+  register Sinatra::Flash
 
   NON_AUTH_PATHS = [
     '/login',

--- a/controllers/policies_controller.rb
+++ b/controllers/policies_controller.rb
@@ -8,9 +8,44 @@ class PoliciesController < BaseController
     erb :policies, locals: { policies: response.body['data']['policies'] }
   end
 
+  get '/policies/new' do
+    erb :new_policy, locals: { csrf_token: request.env['rack.session']['csrf'] }
+  end
+
   get '/policies/:id' do
     response = GraphqlClient.call('get_policy', { id: params[:id] })
 
     erb :policy_details, locals: { policy: response.body['data']['policy'] }
+  end
+
+  post '/policies' do
+    input = {
+      vehicle: {
+        licensePlate: params['vehicle_license_plate'],
+        make: params['vehicle_make'],
+        model: params['vehicle_model'],
+        year: params['vehicle_year']
+      },
+      insured: {
+        name: params['insured_name'],
+        documentNumber: params['insured_document'],
+      }
+    }
+
+    response = GraphqlClient.call('create_policy', input)
+
+    if success?(response)
+      flash[:notice] = { type: 'success', message: 'Apólice criada com sucesso' }
+      redirect('/policies')
+    else
+      flash[:notice] = { type: 'error', message: 'Deu ruim, se ferrou' }
+      redirect('/policies/new')
+    end
+  end
+
+  private
+
+  def success?(response)
+    response.success? && !response.body.has_key?('errors')
   end
 end

--- a/graphql/mutations/policy_mutations.rb
+++ b/graphql/mutations/policy_mutations.rb
@@ -1,0 +1,21 @@
+module Graphql
+  module PolicyMutations
+    def create_policy
+      <<-GRAPHQL
+        mutation CreatePolicy(
+          $vehicle: VehicleInput!,
+          $insured: InsuredInput!
+        ) {
+          createPolicy(
+            input: {
+              attributes: {
+                vehicle: $vehicle,
+                insured: $insured
+              }
+            }
+          ) { message }
+        }
+      GRAPHQL
+    end
+  end
+end

--- a/graphql/operations.rb
+++ b/graphql/operations.rb
@@ -1,9 +1,11 @@
 require_relative './queries/policy_queries'
+require_relative './mutations/policy_mutations'
 
 module Graphql
   class Operations
     class << self
       include PolicyQueries
+      include PolicyMutations
     end
   end
 end

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -1,0 +1,26 @@
+.toast {
+  position: fixed;
+  width: 200px;
+  padding: 0px 10px;
+  text-align: center;
+  font-weight: bold;
+  top: 20px;
+  right: -250px;
+  color: #fff;
+  padding: 15px 20px;
+  border-radius: 5px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  transition: right 0.2s;
+}
+
+.show {
+  right: 20px;
+}
+
+.success {
+  background-color: #16942b;
+}
+
+.error {
+  background-color: #bb0e0e;
+}

--- a/public/css/new_policy.css
+++ b/public/css/new_policy.css
@@ -1,0 +1,17 @@
+h2 {
+  padding: 0 !important;
+}
+
+form {
+  max-width: 400px;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 15px;
+}
+
+button {
+  margin-top: 10px;
+}

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -1,0 +1,11 @@
+function showToast() {
+  const toast = document.getElementById('toast')
+
+  setTimeout(() => {
+    toast.classList.add('show')
+  }, 500)
+
+  setTimeout(() => {
+    toast.classList.remove('show')
+  }, 5000)
+}

--- a/views/index.erb
+++ b/views/index.erb
@@ -2,4 +2,5 @@
 
 <h1>Página inicial</h1>
 
+<a href='/policies/new'>Criar apólice</a><br/><br/>
 <a href='/policies'>Listar apólices</a>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -4,9 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Relabs</title>
+    <link rel='stylesheet' href='/css/common.css'>
+    <script src='/js/common.js'></script>
     <%= yield_content :head %>
   </head>
   <body>
     <%= yield %>
+    <div id='toast' class='toast <%= flash.dig(:notice, :type) %>'>
+      <%= flash.dig(:notice, :message) %>
+    </div>
+    <script>
+      if ('<%= flash[:notice].present? %>' === 'true') showToast()
+    </script>
   </body>
 </html>

--- a/views/new_policy.erb
+++ b/views/new_policy.erb
@@ -1,0 +1,45 @@
+<% content_for :head do %>
+  <link rel='stylesheet' href='/css/new_policy.css'>
+<% end %>
+
+<h1>Criar apólice</h1>
+
+<form method='post' action='/policies'>
+  <input type='hidden' name='authenticity_token' value='<%= csrf_token %>'>
+
+  <h2 style='padding-top: 25px'>Segurado</h2>
+
+  <div class='form-row'>
+    <label for='insured_name'>Nome:</label>
+    <input type='text' id='insured_name' name='insured_name' required>
+  </div>
+
+  <div class='form-row'>
+    <label for='insured_document'>Documento:</label>
+    <input type='text' id='insured_document' name='insured_document' required>
+  </div>
+
+  <h2 style='padding-top: 25px'>Vehicle</h2>
+
+  <div class='form-row'>
+    <label for='vehicle_license_plate'>Placa:</label>
+    <input type='text' id='license_plate' name='vehicle_license_plate' required>
+  </div>
+
+  <div class='form-row'>
+    <label for='vehicle_make'>Marca:</label>
+    <input type='text' id='vehicle_make' name='vehicle_make' required>
+  </div>
+
+  <div class='form-row'>
+    <label for='vehicle_model'>Modelo:</label>
+    <input type='text' id='vehicle_model' name='vehicle_model' required>
+  </div>
+
+  <div class='form-row'>
+    <label for='year'>Ano:</label>
+    <input type='number' id='vehicle_year' name='vehicle_year' required>
+  </div>
+
+  <button type='submit'>Finalizar</button>
+</form>

--- a/views/policies.erb
+++ b/views/policies.erb
@@ -4,7 +4,8 @@
 
 <h1>Apólices</h1>
 
-<table>
+<% if policies.length > 0 %>
+  <table>
   <tr>
     <th>ID</th>
     <th>Nome</th>
@@ -24,3 +25,6 @@
     </tr>
   <% end %>
 </table>
+<% else %>
+  <p>Nenhuma apólice encontrada</p>
+<% end %>


### PR DESCRIPTION
## Motivação
- Permitir que o usuário crie uma apólice

## Solução proposta
- Criação de duas novas rotas (`GET /policies/new` e `POST /policies`)
- Criação de uma nova view (`new_policy.erb`)
- Criação de um novo contrato com o graphql (`createPolicy`)
- Adição da gem `sinatra-flash` para exibir feedback ao usuário

## Images
[policy-creation-form.webm](https://github.com/Almachc/app-web/assets/47675835/1b0ae3ca-0ef6-4360-afc0-4cf69386fe0e)
